### PR TITLE
Fix invalid stale.yml workflow (exempt labels must be strings)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,21 +14,5 @@ jobs:
           close-issue-label: wontfix
           close-pr-label: wontfix
           days-before-close: -1
-          exempt-issue-labels:
-            - pinned
-            - security
-            - Bug
-            - Serious Bug
-            - Minor bug
-            - Black hole bug
-            - Special case Bug
-            - Upstream bug
-          exempt-pr-labels:
-            - pinned
-            - security
-            - Bug
-            - Serious Bug
-            - Minor bug
-            - Black hole bug
-            - Special case Bug
-            - Upstream bug
+          exempt-issue-labels: 'pinned,security,Bug,Serious Bug,Minor bug,Black hole bug,Special case Bug,Upstream bug'
+          exempt-pr-labels: 'pinned,security,Bug,Serious Bug,Minor bug,Black hole bug,Special case Bug,Upstream bug'


### PR DESCRIPTION
## Summary

The `stale.yml` workflow is flagged **Invalid workflow file** on `main`:

> (Line: 18, Col: 13): A sequence was not expected, (Line: 27, Col: 13): A sequence was not expected

`actions/stale` (bumped to v10) requires `with:` inputs to be scalar strings, but `exempt-issue-labels` and `exempt-pr-labels` were written as YAML sequences. This converts them to the comma-separated string form the action expects. No change to which labels are exempt.

## Test Plan
- [x] `stale.yml` parses as valid YAML and both inputs are now strings
- [ ] GitHub no longer reports "Invalid workflow file" once merged